### PR TITLE
leave directory and parentDirectory unencrypted

### DIFF
--- a/src/org/cassproject/ebac/repository/EcEncryptedValue.js
+++ b/src/org/cassproject/ebac/repository/EcEncryptedValue.js
@@ -125,6 +125,13 @@ module.exports = class EcEncryptedValue extends EbacEncryptedValue {
 		if (d["name"] != null) {
 			v.name = d["name"];
 		}
+		// directory and parent directory need to stay unencrypted to be searchable
+		if (d["directory"] != null) {
+			v["directory"] = d["directory"];
+		}
+		if (d["parentDirectory" != null]) {
+			v["parentDirectory"] = d["parentDirectory"];
+		}
 		var newIv = EcAes.newIv(16);
 		var newSecret = EcAes.newIv(16);
 		return this.encryptValueActual(


### PR DESCRIPTION
@Lomilar I think we need to do this to have private frameworks and directories discoverable inside of directories