### PR TITLE
Ignore sample data on import. CASS-914

### DIFF
--- a/src/org/cass/importer/CTDLASNCSVConceptImport.js
+++ b/src/org/cass/importer/CTDLASNCSVConceptImport.js
@@ -74,6 +74,11 @@ module.exports = class CTDLASNCSVConceptImport {
 				var concepts = [];
 				for (let each = 0; each < tabularData.length; each++) {
 					let pretranslatedE = tabularData[each];
+					if (
+						pretranslatedE["@type"].toLowerCase().startsWith('sample')
+					) {
+						continue;
+					}
 					if (pretranslatedE["@type"] == "skos:ConceptScheme") {
 						var translator = new EcLinkedData(null, null);
 						translator.copyFrom(pretranslatedE);

--- a/src/org/cass/importer/CTDLASNCSVImport.js
+++ b/src/org/cass/importer/CTDLASNCSVImport.js
@@ -46,7 +46,7 @@ module.exports = class CTDLASNCSVImport {
 						col[typeCol].trim() == "ceasn:Competency"
 					)
 						competencyCounter++;
-					else if (col[typeCol] == null || col[typeCol] == "")
+					else if (col[typeCol] == null || col[typeCol] == "" || col[typeCol].toLowerCase().startsWith('sample'))
 						continue;
 					else {
 						this.error("Found unknown type:" + col[typeCol]);
@@ -97,6 +97,11 @@ module.exports = class CTDLASNCSVImport {
 				var relationById = {};
 				for (let i = 0; i < tabularData.length; i++) {
 					let pretranslatedE = tabularData[i];
+					if (
+						pretranslatedE["@type"].toLowerCase().startsWith('sample')
+					) {
+						continue;
+					}
 					if (
 						pretranslatedE["@type"] ==
 						"ceasn:CompetencyFramework"
@@ -517,6 +522,11 @@ module.exports = class CTDLASNCSVImport {
 				var relationById = {};
 				for (let i = 0; i < tabularData.length; i++) {
 					let pretranslatedE = tabularData[i];
+					if (
+						pretranslatedE["@type"].toLowerCase().startsWith('sample')
+					) {
+						continue;
+					}
 					if (
 						pretranslatedE["@type"] ==
 						"ceterms:Collection"


### PR DESCRIPTION
Handling import of ctdlasn csv files that contain sample rows of data. These rows are indicated with the word "SAMPLE" preceeding a type. For example, @type set to "SAMPLE: ceasn:CompetencyFramework".
 