### PR TITLE
Add check for blank row in ctdl import

### DIFF
--- a/src/org/cass/importer/CTDLASNCSVImport.js
+++ b/src/org/cass/importer/CTDLASNCSVImport.js
@@ -96,6 +96,9 @@ module.exports = class CTDLASNCSVImport {
 				let relations = [];
 				let relationById = {};
 				for (let i = 0; i < tabularData.length; i++) {
+					if (!tabularData[i]) {
+						continue;
+					}
 					let pretranslatedE = tabularData[i];
 					// Skip extra lines if found in file
 					if (!pretranslatedE || !pretranslatedE["@type"]) {


### PR DESCRIPTION
Addresses an error caused by importing a csv with blank or unreadable rows. 