### PR TITLE
Handle import with multiple CTID properties.

### DIFF
--- a/src/org/cass/importer/CTDLASNCSVImport.js
+++ b/src/org/cass/importer/CTDLASNCSVImport.js
@@ -110,7 +110,9 @@ module.exports = class CTDLASNCSVImport {
 						continue;
 					}
 					if (pretranslatedE["ceterms:CTID"]) {
-						pretranslatedE["ceterms:ctid"] = pretranslatedE["ceterms:CTID"];
+						if (!pretranslatedE["ceterms:ctid"]) {
+							pretranslatedE["ceterms:ctid"] = pretranslatedE["ceterms:CTID"];
+						}
 						delete pretranslatedE["ceterms:CTID"];
 					}
 					if (
@@ -543,7 +545,9 @@ module.exports = class CTDLASNCSVImport {
 						continue;
 					}
 					if (pretranslatedE["ceterms:CTID"]) {
-						pretranslatedE["ceterms:ctid"] = pretranslatedE["ceterms:CTID"];
+						if (!pretranslatedE["ceterms:ctid"]) {
+							pretranslatedE["ceterms:ctid"] = pretranslatedE["ceterms:CTID"];
+						}
 						delete pretranslatedE["ceterms:CTID"];
 					}
 					if (


### PR DESCRIPTION
Handle the case of an export created on a release prior to 1.5.29 from a framework imported via a model containing ceterms:CTID instead of ceterms:ctid. This situation results in ceterms:ctid and ceterms:CTID. Fix accepts ceterms:CTID as ceterms:ctid if, and only if, ceterms:ctid does not exist as well.