### PR TITLE
Kg duplicates on import

### DIFF
--- a/src/org/cass/importer/CTDLASNCSVImport.js
+++ b/src/org/cass/importer/CTDLASNCSVImport.js
@@ -24,13 +24,26 @@ module.exports = class CTDLASNCSVImport {
 				let competencyCounter = 0;
 				let collectionCounter = 0;
 				let typeCol = nameToCol["@type"];
+				let competencyTextCol = nameToCol["ceasn:competencyText"];
+				let uniqueTabularData = [];
 				if (typeCol == null) {
 					this.error("No @type in CSV.");
 					return;
 				}
+				console.log('analyze import...');
 				for (let i = 0; i < tabularData.length; i++) {
 					if (i == 0) continue;
 					let col = tabularData[i];
+					if (uniqueTabularData.find((value) => (value["@type"] === col[typeCol]) &&
+								(value["ceasn:competencyText"] === col[competencyTextCol]))) {
+						console.log("Found possible duplicate: " + col[typeCol] + ": " + col[competencyTextCol]);
+					} else {
+						uniqueTabularData.push({
+							"@type": col[typeCol],
+							"ceasn:competencyText": col[competencyTextCol]
+						});
+					}
+
 					if (
 						col[typeCol] != null &&
 						col[typeCol].trim() == "ceasn:CompetencyFramework"
@@ -53,6 +66,8 @@ module.exports = class CTDLASNCSVImport {
 						return;
 					}
 				}
+				console.log(uniqueTabularData);
+
 				success(frameworkCounter, competencyCounter, collectionCounter);
 			},
 			error: failure

--- a/src/org/cass/importer/CTDLASNCSVImport.js
+++ b/src/org/cass/importer/CTDLASNCSVImport.js
@@ -557,7 +557,7 @@ module.exports = class CTDLASNCSVImport {
 		ceo,
 		endpoint,
 		eim,
-		skipCtids
+		skip
 	) {
 		Papa.parse(file, {
 			header: true,
@@ -590,8 +590,10 @@ module.exports = class CTDLASNCSVImport {
 						delete pretranslatedE["ceterms:CTID"];
 					}
 					// Skip competency if ctid is specified
-					if (skipCtids && Array.isArray(skipCtids) && skipCtids.includes(pretranslatedE["ceterms:ctid"])) {
-						continue;
+					if (skip && Array.isArray(skip) && skip.length > 0) {
+						if (skip.find((element) => element.ctid ? element.ctid.includes(pretranslatedE["ceterms:ctid"]) : element === pretranslatedE["ceterms:ctid"])) {
+							continue;
+						}
 					}
 					if (
 						pretranslatedE["@type"] ==
@@ -651,6 +653,16 @@ module.exports = class CTDLASNCSVImport {
 						frameworkRows[f.shortId()] = e;
 						frameworkArray.push(f);
 						f.competency = f["ceterms:hasMember"] || [];
+						// Remove skipped competencies
+						if (skip && Array.isArray(skip) && skip.length > 0 && f.competency) {
+							skip.forEach((element) => {
+								const id = (element.ctid ? element.ctid : element).replace('ce-', '');								
+								const index = f.competency.findIndex((comp) => comp.includes(id));
+								if (index) {
+									f.competency.splice(index, 1);
+								}
+							});
+						}
 						delete f["ceterms:hasMember"];
 						f.relation = [];
 						f.subType = "Collection";


### PR DESCRIPTION
Detects duplicate competencies when importing Collections and provides user with option to import all duplicates or only one of a set of duplicates (based on CTID). 
https://github.com/cassproject/cass-editor/issues/1312
