### PR TITLE
Re-expand some ceterms on import of concept scheme.

### DIFF
--- a/src/org/cass/importer/CTDLASNCSVConceptImport.js
+++ b/src/org/cass/importer/CTDLASNCSVConceptImport.js
@@ -113,6 +113,10 @@ module.exports = class CTDLASNCSVConceptImport {
 							"https://schema.cassproject.org/0.4/jsonld1.1/ceasn2cassConcepts.json",
 							"https://schema.cassproject.org/0.4/skos"
 						);
+						if (e["ceterms:AgentSector"] != null) {
+							e["https://purl.org/ctdl/terms/AgentSector"] = e["ceterms:AgentSector"];
+							delete e["ceterms:AgentSector"];
+						}
 						e.type = "ConceptScheme";
 						let f = new EcConceptScheme();
 						f.copyFrom(e);


### PR DESCRIPTION
Concept Scheme ids are compacting to ceterms:AgentSector (as an example) on import rather than https://purl.org/ctdl/terms/AgentSector since ceterms is part of the context.

Add a check to the import process to see if the id was compacted. If so, re-expand.
https://github.com/cassproject/cass-editor/issues/591